### PR TITLE
Implement offline-first ledger cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ AI智能記帳系統｜AI-Powered Smart Ledger
    git clone https://github.com/你的帳號/my-ai-ledger.git
    cd my-ai-ledger
 
-## \uD83D\uDCE6 \u96E2\u7DDA\u6A21\u5F0F (Offline Mode)
-- \u5F9E IndexedDB \u8B80\u53D6\u8CC7\u6599\uFF0C\u5728\u80CC\u666F\u8207 API \u540C\u6B65
-- \u672A\u540C\u6B65\u7684\u65B0\u589E\u7D00\u9304\u6703\u81EA\u52D5\u4E0A\u50B3
+## 📦 離線模式 (Offline Mode)
+- 從 IndexedDB 讀取資料，在背景與 API 同步
+- 未同步的新增加紀錄會自動上傳

--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ AI智能記帳系統｜AI-Powered Smart Ledger
    ```bash
    git clone https://github.com/你的帳號/my-ai-ledger.git
    cd my-ai-ledger
+
+## \uD83D\uDCE6 \u96E2\u7DDA\u6A21\u5F0F (Offline Mode)
+- \u5F9E IndexedDB \u8B80\u53D6\u8CC7\u6599\uFF0C\u5728\u80CC\u666F\u8207 API \u540C\u6B65
+- \u672A\u540C\u6B65\u7684\u65B0\u589E\u7D00\u9304\u6703\u81EA\u52D5\u4E0A\u50B3

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "pg": "^8.16.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "typeorm": "^0.3.24"
+    "typeorm": "^0.3.24",
+    "dexie": "^3.2.4",
+    "next-pwa": "^7.2.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/ask/route.ts
+++ b/src/app/api/ask/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: NextRequest) {
   try {
     const result = await routerChain(question);
     return NextResponse.json({ result });
-  } catch (e) {
+  } catch (e: any) {
     return NextResponse.json({ error: e.message || String(e) }, { status: 500 });
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,9 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import LedgerList from '@/components/LedgerList';
 import LedgerAsk from '@/components/LedgerAsk';
+import { addLedger } from '@/lib/useLedger';
 
 export default function Home() {
   const [description, setDescription] = useState('');
@@ -10,13 +11,15 @@ export default function Home() {
   const [category, setCategory] = useState('');
 
   const handleAdd = async () => {
-    const res = await fetch('/api/ledger', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ description, amount: Number(amount), category }),
+    await addLedger({
+      description,
+      amount: Number(amount),
+      category,
+      type: 'expense',
     });
-    const data = await res.json();
-    alert(JSON.stringify(data));
+    setDescription('');
+    setAmount('');
+    setCategory('');
   };
 
   return (

--- a/src/components/LedgerList.tsx
+++ b/src/components/LedgerList.tsx
@@ -1,14 +1,7 @@
 'use client';
-import { useState, useEffect } from 'react';
-
-type LedgerItem = {
-  id: number;
-  created_at: string;
-  description: string;
-  amount: number;
-  category: string;
-  type: string; // income/expense
-};
+import { useState } from 'react';
+import { useLedger } from '@/lib/useLedger';
+import type { LedgerRecord } from '@/lib/localDb';
 
 function formatMonth(date: Date) {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
@@ -21,21 +14,7 @@ export default function LedgerList() {
     return formatMonth(now); // e.g. "2024-06"
   });
 
-  const [records, setRecords] = useState<LedgerItem[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  // 查詢資料
-  useEffect(() => {
-    setLoading(true);
-    // 傳給 API 的參數，取該月的第一天
-    const [year, month] = currentMonth.split('-').map(Number);
-    const dateParam = `${year}-${String(month).padStart(2, '0')}-01`;
-
-    fetch(`/api/ledger?date=${dateParam}`)
-      .then(res => res.json())
-      .then(res => setRecords(res.data || []))
-      .finally(() => setLoading(false));
-  }, [currentMonth]);
+  const { records, loading } = useLedger(currentMonth);
 
   // 切換月份
   function handleMonthChange(diff: number) {

--- a/src/lib/localDb.ts
+++ b/src/lib/localDb.ts
@@ -1,0 +1,121 @@
+export interface LedgerRecord {
+  id?: number;
+  description: string;
+  amount: number;
+  category: string;
+  type: string;
+  created_at: string;
+  synced?: boolean;
+}
+
+const DB_NAME = 'ledger-db';
+const STORE_NAME = 'ledger';
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      const store = db.createObjectStore(STORE_NAME, {
+        keyPath: 'id',
+        autoIncrement: true,
+      });
+      store.createIndex('created_at', 'created_at');
+      store.createIndex('synced', 'synced');
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function withStore<T>(
+  mode: IDBTransactionMode,
+  callback: (store: IDBObjectStore) => void
+): Promise<T> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, mode);
+    const store = tx.objectStore(STORE_NAME);
+    callback(store);
+    tx.oncomplete = () => resolve(undefined as T);
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function addLocal(record: Omit<LedgerRecord, 'id'>): Promise<LedgerRecord> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.add(record);
+    req.onsuccess = () => resolve({ ...record, id: req.result as number });
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function updateLocal(id: number, data: Partial<LedgerRecord>) {
+  const db = await openDB();
+  return new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const getReq = store.get(id);
+    getReq.onsuccess = () => {
+      const record = { ...(getReq.result as LedgerRecord), ...data };
+      store.put(record);
+    };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function recordsByMonth(month: string): Promise<LedgerRecord[]> {
+  const db = await openDB();
+  const [y, m] = month.split('-').map(Number);
+  const start = new Date(y, m - 1, 1).toISOString();
+  const end = new Date(y, m, 0, 23, 59, 59).toISOString();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME);
+    const index = tx.objectStore(STORE_NAME).index('created_at');
+    const range = IDBKeyRange.bound(start, end);
+    const res: LedgerRecord[] = [];
+    index.openCursor(range).onsuccess = (e: any) => {
+      const cursor = e.target.result as IDBCursorWithValue | null;
+      if (cursor) {
+        res.push(cursor.value as LedgerRecord);
+        cursor.continue();
+      } else {
+        resolve(res);
+      }
+    };
+    index.openCursor(range).onerror = () => reject(tx.error);
+  });
+}
+
+export async function unsyncedRecords(): Promise<LedgerRecord[]> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME);
+    const index = tx.objectStore(STORE_NAME).index('synced');
+    const req = index.getAll(IDBKeyRange.only(false));
+    req.onsuccess = () => resolve(req.result as LedgerRecord[]);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function removeOld(before: Date) {
+  const db = await openDB();
+  return new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const index = tx.objectStore(STORE_NAME).index('created_at');
+    const range = IDBKeyRange.upperBound(before.toISOString(), true);
+    index.openCursor(range).onsuccess = (e: any) => {
+      const cursor = e.target.result as IDBCursorWithValue | null;
+      if (cursor) {
+        cursor.delete();
+        cursor.continue();
+      }
+    };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}

--- a/src/lib/useLedger.ts
+++ b/src/lib/useLedger.ts
@@ -1,0 +1,81 @@
+'use client';
+import { useEffect, useState } from 'react';
+import {
+  LedgerRecord,
+  addLocal,
+  updateLocal,
+  recordsByMonth,
+  unsyncedRecords,
+  removeOld,
+} from './localDb';
+
+export function useLedger(month: string) {
+  const [records, setRecords] = useState<LedgerRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      const local = await recordsByMonth(month);
+      setRecords(local);
+
+      // keep only last 6 months
+      const before = new Date();
+      before.setMonth(before.getMonth() - 6);
+      await removeOld(before);
+
+      // sync unsynced
+      const pending = await unsyncedRecords();
+      for (const item of pending) {
+        try {
+          const res = await fetch('/api/ledger', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              description: item.description,
+              amount: item.amount,
+              category: item.category,
+              type: item.type,
+            }),
+          });
+          const data = await res.json();
+          if (data.data && data.data[0]) {
+            await updateLocal(item.id!, { ...data.data[0], synced: true });
+          }
+        } catch (e) {
+          console.error('sync failed', e);
+        }
+      }
+
+      try {
+        const [y, m] = month.split('-').map(Number);
+        const dateParam = `${y}-${String(m).padStart(2, '0')}-01`;
+        const res = await fetch(`/api/ledger?date=${dateParam}`);
+        const data = await res.json();
+        if (data.data) {
+          for (const d of data.data) {
+            await updateLocal(d.id, { ...d, synced: true });
+          }
+          const updated = await recordsByMonth(month);
+          setRecords(updated);
+        }
+      } catch (e) {
+        console.error('fetch remote failed', e);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [month]);
+
+  return { records, loading };
+}
+
+export async function addLedger(record: Omit<LedgerRecord, 'id' | 'created_at' | 'synced'>) {
+  const item: LedgerRecord = {
+    ...record,
+    created_at: new Date().toISOString(),
+    synced: false,
+  };
+  await addLocal(item);
+}


### PR DESCRIPTION
## Summary
- add local IndexedDB helpers
- sync ledger data offline-first in a new hook
- update components to use the hook
- remove external fonts from layout for offline build
- document offline mode in README

## Testing
- `npm run build` *(fails: Error: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_685e47826d5c83279a2487c975110f8d